### PR TITLE
Added StartupWMClass

### DIFF
--- a/com.tutanota.Tutanota.desktop
+++ b/com.tutanota.Tutanota.desktop
@@ -7,3 +7,4 @@ Exec=tutanota-desktop %U
 Icon=com.tutanota.Tutanota
 MimeType=x-scheme-handler/mailto;
 Categories=Email;Network;
+StartupWMClass=tutanota-desktop


### PR DESCRIPTION
When Tutanota starts, the window wasn't associated with the .desktop launcher.