### PR TITLE
desktop: add genericname entry and i18n

### DIFF
--- a/com.tutanota.Tutanota.desktop
+++ b/com.tutanota.Tutanota.desktop
@@ -1,10 +1,22 @@
 [Desktop Entry]
-Version=1.0
+Version=1.2
 Type=Application
 Name=Tutanota
-Comment=Email client
+GenericName=Email client
+GenericName[bs]=Mejl klijent
+GenericName[nl]=E-mail client
+GenericName[no]=E-postklient
+GenericName[sv]=E-post klient
+Comment=Secure email for everybody.
+Comment[nl]=Beveiligde e-mail voor iedereen.
+Comment[no]=Sikker e-post for alle.
+Comment[sv]=Säker e-post för alla.
 Exec=tutanota-desktop %U
 Icon=com.tutanota.Tutanota
 MimeType=x-scheme-handler/mailto;
 Categories=Email;Network;
 StartupWMClass=tutanota-desktop
+Keywords=email;e-mail;
+Keywords[nl]=e-mail;
+Keywords[no]=e-post;
+Keywords[sv]=e-post;e-mail;mail;mejl;


### PR DESCRIPTION
### GenericName vs Comment
Previously Tutanota was using the `Comment` section more like `GenericName`.

> GenericName: Generic name of the application, for example "Web Browser".
> 
> Comment: Tooltip for the entry, for example "View sites on the Internet". The value should not be redundant with the values of Name and GenericName. 
>
> \- https://specifications.freedesktop.org/desktop-entry-spec/1.2/ar01s06.html

This updates `GenericName` to be the generic name of "Email client".
The comment would be up to you all, I just took the line from Tutanota's landing page.

### Internationalization
Added some for the non-English natives. Desktop Entry files can have translations by specifying the locale in [] after the key.
All translations in the PR are made by humans.

### Keywords
In the Desktop Entry 1.1 specifications, support for "Keywords" was added.

> Add Keyword key. 
> \- https://specifications.freedesktop.org/desktop-entry-spec/latest/apes04.html

> A list of strings which may be used in addition to other metadata to describe this entry. This can be useful e.g. to facilitate searching through entries. The values are not meant for display, and should not be redundant with the values of `Name` or `GenericName`. 
> 
> \- https://specifications.freedesktop.org/desktop-entry-spec/1.2/ar01s06.html

### Other Info
TL;DR This shouldn't really change anything about Tutanota, but can make it easier to find since there is more searchable criteria, especially for non-English users.

You can see other examples, just to verify these aren't foreign or weird changes:
* https://github.com/flathub/org.mozilla.Thunderbird/blob/master/org.mozilla.Thunderbird.desktop
* https://github.com/flathub/com.visualstudio.code/blob/master/com.visualstudio.code.desktop