### PR TITLE
Drop `org.kde.*` own-name

### DIFF
--- a/com.tutanota.Tutanota.json
+++ b/com.tutanota.Tutanota.json
@@ -28,8 +28,7 @@
     "--talk-name=org.freedesktop.Notifications",
     "--talk-name=org.kde.StatusNotifierWatcher",
     "--talk-name=org.freedesktop.portal.Background",
-    "--talk-name=org.freedesktop.portal.Fcitx",
-    "--own-name=org.kde.*"
+    "--talk-name=org.freedesktop.portal.Fcitx"
   ],
   "modules": [
     "shared-modules/libsecret/libsecret.json",


### PR DESCRIPTION
This is no longer required with newer Electron and runtime

https://docs.flatpak.org/en/latest/desktop-integration.html#statusnotifier

> Most implementations of StatusNotifer have dropped this requirement
> but known exceptions to this are Electron versions older than 23.3.0.

Current version uses Electron 26.2.2
https://github.com/tutao/tutanota/blob/6af9e8d02cba661cbb271c02c292a036a32624ad/package-lock.json#L4580