### PR TITLE
Update freedesktop sdk to latest

### DIFF
--- a/com.tutanota.Tutanota.json
+++ b/com.tutanota.Tutanota.json
@@ -1,9 +1,9 @@
 {
   "app-id": "com.tutanota.Tutanota",
   "runtime": "org.freedesktop.Platform",
-  "runtime-version": "22.08",
+  "runtime-version": "23.08",
   "base": "org.electronjs.Electron2.BaseApp",
-  "base-version": "22.08",
+  "base-version": "23.08",
   "sdk": "org.freedesktop.Sdk",
   "command": "tutanota-desktop",
   "separate-locales": false,
@@ -14,7 +14,6 @@
     "--socket=wayland",
     "--socket=pulseaudio",
     "--share=network",
-    "--talk-name=org.freedesktop.Notifications",
     "--talk-name=org.freedesktop.secrets",
     "--talk-name=org.kde.StatusNotifierWatcher",
     "--env=TMPDIR=/var/tmp",
@@ -27,9 +26,6 @@
     "--filesystem=xdg-public-share",
     "--filesystem=xdg-videos",
     "--filesystem=xdg-run/keyring",
-    "--talk-name=org.freedesktop.Notifications",
-    "--talk-name=org.kde.StatusNotifierWatcher",
-    "--talk-name=org.freedesktop.portal.Background",
     "--talk-name=org.freedesktop.portal.Fcitx"
   ],
   "modules": [

--- a/manifest-template.js
+++ b/manifest-template.js
@@ -6,9 +6,9 @@ const [hash, url] = process.argv.slice(2)
 const manifest = {
 	"app-id": "com.tutanota.Tutanota",
 	"runtime": "org.freedesktop.Platform",
-	"runtime-version": "22.08",
+	"runtime-version": "23.08",
 	"base": "org.electronjs.Electron2.BaseApp",
-	"base-version": "22.08",
+	"base-version": "23.08",
 	"sdk": "org.freedesktop.Sdk",
 	"command": "tutanota-desktop",
 	"separate-locales": false,
@@ -19,7 +19,6 @@ const manifest = {
 		"--socket=x11",
 		"--socket=pulseaudio",
 		"--share=network",
-		"--talk-name=org.freedesktop.Notifications",
 		"--talk-name=org.freedesktop.secrets",
 		"--talk-name=org.kde.StatusNotifierWatcher",
 		"--env=TMPDIR=/var/tmp",
@@ -32,9 +31,6 @@ const manifest = {
 		"--filesystem=xdg-public-share",
 		"--filesystem=xdg-videos",
 		"--filesystem=xdg-run/keyring",
-		"--talk-name=org.freedesktop.Notifications",
-		"--talk-name=org.kde.StatusNotifierWatcher",
-		"--talk-name=org.freedesktop.portal.Background",
 		"--talk-name=org.freedesktop.portal.Fcitx"
 	],
 	"modules": [


### PR DESCRIPTION
This PR also removes unneeded permissions. For rationale behind removing them see [here](https://github.com/flathub/org.signal.Signal/pull/524) and [here](https://github.com/flathub/org.signal.Signal/pull/525). Also I have removed redundant permissions that are 2 times in manifest.