### PR TITLE
Re-write of the existing manifest from JSON to yaml

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 .idea/**/*
 *.tar.gz
+.flatpak-builder/
+build/

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,35 @@
+FLATPAK := $(shell which flatpak)
+FLATPAK_BUILDER := $(shell which flatpak-builder)
+
+FLATPAK_MANIFEST=com.tutanota.Tutanota.yaml
+FLATPAK_APPID=com.tutanota.Tutanota
+
+FLATPAK_BUILD_FLAGS := --verbose --force-clean --install-deps-from=flathub --ccache
+FLATPAK_INSTALL_FLAGS := --verbose --force-clean --ccache --user --install
+FLATPAK_DEBUG_FLAGS := --verbose --run
+
+all: build
+
+.PHONY: build
+build:
+	$(FLATPAK_BUILDER) build $(FLATPAK_BUILD_FLAGS) $(FLATPAK_MANIFEST)
+
+.PHONY: debug
+debug:
+	$(FLATPAK_BUILDER) $(FLATPAK_DEBUG_FLAGS) build $(FLATPAK_MANIFEST) sh
+
+.PHONY: debug-installed
+debug-installed:
+	$(FLATPAK) run --command=sh --devel $(FLATPAK_APPID)
+
+.PHONY: install
+install:
+	$(FLATPAK_BUILDER) build $(FLATPAK_INSTALL_FLAGS) $(FLATPAK_MANIFEST)
+
+.PHONY: uninstall
+uninstall:
+	$(FLATPAK) uninstall $(FLATPAK_APPID)
+
+.PHONY: run
+run:
+	$(FLATPAK) run $(FLATPAK_APPID)

--- a/com.tutanota.Tutanota.yaml
+++ b/com.tutanota.Tutanota.yaml
@@ -1,0 +1,84 @@
+id: com.tutanota.Tutanota
+runtime: org.freedesktop.Platform
+runtime-version: '23.08'
+base: org.electronjs.Electron2.BaseApp
+base-version: '23.08'
+sdk: org.freedesktop.Sdk
+command: tutanota-desktop
+separate-locales: false
+rename-icon: tutanota-desktop
+finish-args:
+  # X11 performance
+  - --share=ipc
+  # OpenGL rendering
+  - --device=dri
+  # Access to wayland
+  - --socket=wayland
+  # We need X11
+  - --socket=x11
+  # Audio Access
+  - --socket=pulseaudio
+  # Network Access
+  - --share=network
+  - --talk-name=org.freedesktop.secrets
+  - --talk-name=org.kde.StatusNotifierWatcher
+  # File system Access
+  - --filesystem=host:ro
+  - --filesystem=xdg-desktop
+  - --filesystem=xdg-documents
+  - --filesystem=xdg-download
+  - --filesystem=xdg-music
+  - --filesystem=xdg-pictures
+  - --filesystem=xdg-public-share
+  - --filesystem=xdg-videos
+  - --filesystem=xdg-run/keyring
+  # Allow advanced input methods
+  - --talk-name=org.freedesktop.portal.Fcitx
+modules:
+  - name: libsecret
+    buildsystem: meson
+    config-opts:
+      - -Dmanpage=false
+      - -Dvapi=false
+      - -Dgtk_doc=false
+      - -Dintrospection=false
+    cleanup:
+      - /bin
+      - /include
+      - /lib/pkgconfig
+      - /share/man
+    sources:
+      - type: git
+        url: https://github.com/tutao/libsecret.git
+        commit: 3d18f7e928d6de69457ec3d18d5ca84923191957
+
+  - name: tutanota
+    buildsystem: simple
+    sources:
+      - type: file
+        dest-filename: tutanota-desktop.tar.gz
+        url: https://github.com/tutao/tutanota/releases/download/tutanota-desktop-release-3.119.3/tutanota-desktop-3.119.3-unpacked-linux.tar.gz
+        sha256: 4dd8ef535da7875b137c64dd067fbb75b12e9da177f188c3bdc7849ece2245b0
+      - type: script
+        dest-filename: tutanota-desktop.sh
+        commands:
+          - export TMPDIR="${XDG_RUNTIME_DIR}/app/${FLATPAK_ID}"
+          - exec zypak-wrapper /app/tutanota/tutanota-desktop --ozone-platform-hint=auto "$@"
+    build-commands:
+      - tar -xf tutanota-desktop.tar.gz --transform="s/linux-unpacked/tutanota/" --directory="${FLATPAK_DEST}"
+      - |
+          for size in 64 512; do
+            install -Dm0644 "${FLATPAK_DEST}/tutanota/resources/icons/icon/${size}.png" "${FLATPAK_DEST}/share/icons/hicolor/${size}x${size}/apps/tutanota-desktop.png"
+          done
+      - install -Dm0755 tutanota-desktop.sh "${FLATPAK_DEST}/bin/tutanota-desktop"
+
+  - name: metadata
+    buildsystem: simple
+    sources:
+      - type: file
+        path: com.tutanota.Tutanota.appdata.xml
+      - type: file
+        path: com.tutanota.Tutanota.desktop
+    build-commands:
+      - install -Dm0644 com.tutanota.Tutanota.appdata.xml "${FLATPAK_DEST}/share/metainfo/${FLATPAK_ID}.appdata.xml"
+      - install -Dm0644 com.tutanota.Tutanota.desktop "${FLATPAK_DEST}/share/applications/${FLATPAK_ID}.desktop"


### PR DESCRIPTION
Some minor tweaks done on the way such as simplified archive handling and moving the executable file away from the flatpak lib folder.

The TMPDIR finish arg is also removed, as I didnt see it used anywhere.

A small Makefile is added for simpler usage of flatpak and flatpak-builder when developing.

Finally, the gitignore is trimmed to exclude temporary flatpak build files.