### PR TITLE
Address Electron system dbus error

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 FLATPAK := $(shell which flatpak)
 FLATPAK_BUILDER := $(shell which flatpak-builder)
 
-FLATPAK_MANIFEST=com.tutanota.Tutanota.yml
+FLATPAK_MANIFEST=com.tutanota.Tutanota.json
 FLATPAK_APPID=com.tutanota.Tutanota
 
 FLATPAK_BUILD_FLAGS := --verbose --force-clean --install-deps-from=flathub --ccache

--- a/com.tutanota.Tutanota.json
+++ b/com.tutanota.Tutanota.json
@@ -26,7 +26,8 @@
     "--filesystem=xdg-public-share",
     "--filesystem=xdg-videos",
     "--filesystem=xdg-run/keyring",
-    "--talk-name=org.freedesktop.portal.Fcitx"
+    "--talk-name=org.freedesktop.portal.Fcitx",
+    "--system-talk-name=org.freedesktop.login1"
   ],
   "modules": [
     {

--- a/manifest-template.js
+++ b/manifest-template.js
@@ -31,7 +31,8 @@ const manifest = {
 		"--filesystem=xdg-public-share",
 		"--filesystem=xdg-videos",
 		"--filesystem=xdg-run/keyring",
-		"--talk-name=org.freedesktop.portal.Fcitx"
+		"--talk-name=org.freedesktop.portal.Fcitx",
+		"--system-talk-name=org.freedesktop.login1"
 	],
 	"modules": [
 		{


### PR DESCRIPTION
When starting the flatpak app, the following error is listed in the console:

> [2:0106/161152.261636:ERROR:bus.cc(399)] Failed to connect to the bus: Failed to connect to socket /run/dbus/system_bus_socket: No such file or directory

This is because Chrome / Electron during startup by default tries to access the credential wallet per dbus. Adding this configuration avoids this failure.

https://www.freedesktop.org/software/systemd/man/latest/org.freedesktop.login1.html