### PR TITLE
Allow window bar to adhere to dark/light mode

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 FLATPAK := $(shell which flatpak)
 FLATPAK_BUILDER := $(shell which flatpak-builder)
 
-FLATPAK_MANIFEST=com.tutanota.Tutanota.yml
+FLATPAK_MANIFEST=com.tutanota.Tutanota.json
 FLATPAK_APPID=com.tutanota.Tutanota
 
 FLATPAK_BUILD_FLAGS := --verbose --force-clean --install-deps-from=flathub --ccache

--- a/com.tutanota.Tutanota.json
+++ b/com.tutanota.Tutanota.json
@@ -67,7 +67,7 @@
           "dest-filename": "tutanota-desktop.sh",
           "commands": [
             "export TMPDIR=\"$XDG_RUNTIME_DIR/app/${FLATPAK_ID}\"",
-            "exec zypak-wrapper /app/lib/tutanota/tutanota-desktop --ozone-platform-hint=auto \"$@\""
+            "exec zypak-wrapper /app/lib/tutanota/tutanota-desktop \"$@\""
           ]
         }
       ],

--- a/manifest-template.js
+++ b/manifest-template.js
@@ -72,7 +72,7 @@ const manifest = {
 					"dest-filename": "tutanota-desktop.sh",
 					"commands": [
 						"export TMPDIR=\"$XDG_RUNTIME_DIR/app/${FLATPAK_ID}\"",
-						"exec zypak-wrapper /app/lib/tutanota/tutanota-desktop --ozone-platform-hint=auto \"$@\""
+						"exec zypak-wrapper /app/lib/tutanota/tutanota-desktop \"$@\""
 					]
 				}
 			],


### PR DESCRIPTION
The Electron/Wayland support is not supporting switching the window bar from light to dark without huge hacks (https://github.com/flathub/com.spotify.Client/blob/master/set-dark-theme-variant.py).

I propose to instead remove the ozone platform hint for now until the Chromium / Electron Wayland support is more mature. This runs Electron with X11. 

This is unfortunately the case for many Electron based Flatpaks at the moment, see for example the note [here](https://github.com/flathub/org.signal.Signal/#wayland) 

This closes https://github.com/flathub/com.tutanota.Tutanota/issues/151

![tutanota-with-dark-titlebar](https://github.com/flathub/com.tutanota.Tutanota/assets/488769/9ccdd343-9a89-4870-957a-b4c5e001b2a1)
