### PR TITLE
Add --device=all for FIDO/U2F keys

### DIFF
--- a/com.tutanota.Tutanota.json
+++ b/com.tutanota.Tutanota.json
@@ -17,6 +17,7 @@
     "--talk-name=org.freedesktop.secrets",
     "--talk-name=org.kde.StatusNotifierWatcher",
     "--env=TMPDIR=/var/tmp",
+    "--device=all",
     "--filesystem=host:ro",
     "--filesystem=xdg-desktop",
     "--filesystem=xdg-documents",

--- a/manifest-template.js
+++ b/manifest-template.js
@@ -22,6 +22,7 @@ const manifest = {
 		"--talk-name=org.freedesktop.secrets",
 		"--talk-name=org.kde.StatusNotifierWatcher",
 		"--env=TMPDIR=/var/tmp",
+		"--device=all",
 		"--filesystem=host:ro",
 		"--filesystem=xdg-desktop",
 		"--filesystem=xdg-documents",


### PR DESCRIPTION
Hi, I'm using Yubikey and it is required permission to use that. I know it's a large access but currently there is no better way to do it in flatpak.
