### PR TITLE
Remove filesystem access from manifest

### DIFF
--- a/com.tutanota.Tutanota.json
+++ b/com.tutanota.Tutanota.json
@@ -18,15 +18,6 @@
     "--talk-name=org.kde.StatusNotifierWatcher",
     "--env=TMPDIR=/var/tmp",
     "--device=all",
-    "--filesystem=host:ro",
-    "--filesystem=xdg-desktop",
-    "--filesystem=xdg-documents",
-    "--filesystem=xdg-download",
-    "--filesystem=xdg-music",
-    "--filesystem=xdg-pictures",
-    "--filesystem=xdg-public-share",
-    "--filesystem=xdg-videos",
-    "--filesystem=xdg-run/keyring"
   ],
   "modules": [
     {

--- a/manifest-template.js
+++ b/manifest-template.js
@@ -23,15 +23,6 @@ const manifest = {
 		"--talk-name=org.kde.StatusNotifierWatcher",
 		"--env=TMPDIR=/var/tmp",
 		"--device=all",
-		"--filesystem=host:ro",
-		"--filesystem=xdg-desktop",
-		"--filesystem=xdg-documents",
-		"--filesystem=xdg-download",
-		"--filesystem=xdg-music",
-		"--filesystem=xdg-pictures",
-		"--filesystem=xdg-public-share",
-		"--filesystem=xdg-videos",
-		"--filesystem=xdg-run/keyring"
 	],
 	"modules": [
 		{


### PR DESCRIPTION
This makes sandbox more strict while retaining existing functionality.

Fixes #17
Fixes #176
